### PR TITLE
Update installation instructions for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,25 @@ Run production webservers such as [pyuwsgi](https://pypi.org/project/pyuwsgi/) (
 1. Install a variant:
 
     ```
-    pip install django-webserver[pyuwsgi]
+    pip install 'django-webserver[pyuwsgi]'
     ```
 
     or
 
     ```
-    pip install django-webserver[gunicorn]
+    pip install 'django-webserver[gunicorn]'
     ```
 
     or
 
     ```
-    pip install django-webserver[uvicorn]  # Python 3.5+ only
+    pip install 'django-webserver[uvicorn]'  # Python 3.5+ only
     ```
 
     or
 
     ```
-    pip install django-webserver[waitress]
+    pip install 'django-webserver[waitress]'
     ```
 
 2. Add to `INSTALLED_APPS`:


### PR DESCRIPTION
`zsh` is the default shell on macOS these days and returns this error:
```
% pip install django-webserver[gunicorn] 
zsh: no matches found: django-webserver[gunicorn]
```
The fix (which continues to work with `bash` as well) is to add single quotes:
```
% pip install 'django-webserver[gunicorn]'
Requirement already satisfied: django-webserver[gunicorn] in ...
```